### PR TITLE
upstream-cookiecutter-sync

### DIFF
--- a/cookiecutter/salt-formula/README.rst
+++ b/cookiecutter/salt-formula/README.rst
@@ -9,8 +9,39 @@ Installation
 .. code-block:: bash
 
     pip install cookiecutter
- 
+
     cd cookiecutter
 
     cookiecutter salt-formula
+
+
+Init Test Kitchen configuration
+===============================
+
+Follow the `salt formula testing <https://salt-formulas.readthedocs.io/en/latest/develop/testing-formulas.html>`_ guidelines and
+automated CI in the main `documentation <https://salt-formulas.readthedocs.io/en/latest/develop/testing.html>`_.
+
+To generate ``.kitchen.yml`` for new or existing project:
+
+- install `envtpl`, renders jinja2 templates with shell environment variables
+- install required gems, it depends on drivers configured to be used (docker by default)
+
+.. code-block:: shell
+
+    pip install envtpl
+    gem install kitchen-docker kitchen-salt [kitchen-openstack kitchen-vagrant kitchen-inspec busser-serverspec]
+
+Once you create your `tests/pillar` structure (required if you want to auto-populate kitchen yaml with test suites)
+
+.. code-block:: shell
+
+    # cd <formula repository>
+    ../kitchen-init.sh
+
+Instantly, to add kitchen configuration into existing repository:
+
+.. code-block:: shell
+
+    # cd <formula repository>
+    curl -skL "https://raw.githubusercontent.com/salt-formulas/salt-formulas/master/cookiecutter/salt-formula/kitchen-init.sh" | bash -s --
 

--- a/cookiecutter/salt-formula/cookiecutter.json
+++ b/cookiecutter/salt-formula/cookiecutter.json
@@ -4,4 +4,9 @@
     "copyright_year": "2017",
     "copyright_holder": "Your Name et al.",
     "author_contact": "name@domain.com"
+
+    "kitchen_driver": "docker",
+    "kitchen_verifier": "inspec",
+    "kitchen_formula": "{{ cookiecutter.service_name }}",
+    "kitchen_suites": ""
 }

--- a/cookiecutter/salt-formula/kitchen-init.sh
+++ b/cookiecutter/salt-formula/kitchen-init.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Script to add Kitchen configuration to existing formulas.
+# usage:
+# curl -skL "https://raw.githubusercontent.com/salt-formulas/salt-formulas/master/cookiecutter/salt-formula/kitchen-init.sh" | bash -s --
+
+# source gist:
+# https://gist.github.com/epcim/b0368794e69e6807635b0c7268e5ceec
+
+# CONFIG
+###################################
+
+export driver=${driver:-docker}       # vagrant, dokken, openstack, ...
+export verifier=${verifier:-inspec}   # serverspec, pester
+
+export formula=${formula:-$(awk -F: '/^name/{gsub(/[\ \"]/,"");print $2}' metadata.yml)}
+export suites=$(ls tests/pillar|xargs -I{} basename {} .sls)
+
+export SOURCE_REPO_URI="https://raw.githubusercontent.com/salt-formulas/salt-formulas/master/cookiecutter/salt-formula/%7B%7Bcookiecutter.service_name%7D%7D"
+
+which envtpl &> /dev/null || {
+  echo "ERROR: missing prerequisite, install 'envtpl' first : sudo pip install envtpl"
+  exit 1
+}
+
+# INIT
+###################################
+test ! -e .kitchen.yml || {
+  kitchen init -D kitchen-docker -P kitchen-salt --no-create-gemfile
+  echo .kitchen >> .gitignore
+  echo .bundle  >> .gitignore
+  echo .vendor  >> .gitignore
+  rm -rf test
+  rm -f .kitchen.yml
+  rm -f chefignore
+}
+
+
+# CONFIGURE & SCAFFOLD TEST DIR
+###################################
+test -d tests/integration || {
+    mkdir -p tests/integration
+}
+# Generate suites:
+#  for suite in $(echo $suites|xargs); do
+#    mkdir -p tests/integration/$suite/$verifier
+#    touch    tests/integration/$suite/$verifier/default_spec.rb
+#  done
+#  mkdir -p tests/integration/helpers/$verifier/
+#  touch    tests/integration/helpers/$verifier/spec_helper.rb
+#}
+
+
+# .KITCHEN.YML
+###################################
+
+test -e .kitchen.yml || \
+  envtpl < <(curl -skL  "${SOURCE_REPO_URI}/.kitchen.${driver}.yml" -- | sed 's/cookiecutter\.kitchen_//g' ) > .kitchen.yml
+
+[[ "$driver" != "docker" ]] && {
+  test -e .kitchen.docker.yml || \
+    envtpl < <(curl -skL  "${SOURCE_REPO_URI}/.kitchen.docker.yml" -- | sed 's/cookiecutter\.kitchen_//g') > .kitchen.docker.yml
+}
+
+[[ "$driver" != "vagrant" ]] && {
+  test -e .kitchen.vagrant.yml || \
+    envtpl < <(curl -skL  "${SOURCE_REPO_URI}/.kitchen.vagrant.yml" -- | sed 's/cookiecutter\.kitchen_//g') > .kitchen.vagrant.yml
+}
+
+[[ "$driver" != "openstack" ]] && {
+  test -e .kitchen.openstack.yml || \
+    envtpl < <(curl -skL  "${SOURCE_REPO_URI}/.kitchen.openstack.yml" -- | sed 's/cookiecutter\.kitchen_//g') > .kitchen.openstack.yml
+}
+
+
+# ADD CHANGES
+#############
+
+echo "**************************************"
+echo "To update to latest test scripts, run:"
+echo "SOURCE_REPO_URI=${SOURCE_REPO_URI}"
+echo 'curl -skL  "${SOURCE_REPO_URI}/Makefile" -o Makefile'
+echo 'curl -skL  "${SOURCE_REPO_URI}/tests/run_tests.sh" -o tests/run_tests.sh'
+
+git add \
+  .gitignore \
+  .kitchen.${driver}.yml
+
+git status

--- a/cookiecutter/salt-formula/{{cookiecutter.service_name}}/.kitchen.docker.yml
+++ b/cookiecutter/salt-formula/{{cookiecutter.service_name}}/.kitchen.docker.yml
@@ -2,7 +2,6 @@
 driver:
   name: docker
   hostname: {{ cookiecutter.kitchen_formula }}.ci.local
-  #socket: tcp://127.0.0.1:2376
   use_sudo: false
 
 
@@ -13,8 +12,10 @@ provisioner:
   salt_bootstrap_url: https://bootstrap.saltstack.com
   salt_version: latest
   require_chef: false
+  log_level: error
   formula: {{ cookiecutter.kitchen_formula }}
-  log_level: info
+  grains:
+    noservices: {{ 'True' if cookiecutter.kitchen_driver =='docker' else 'False' }}
   state_top:
     base:
       "*":
@@ -24,22 +25,22 @@ provisioner:
       base:
         "*":
           - {{ cookiecutter.kitchen_formula }}
-  grains:
-    noservices: {{ 'True' if cookiecutter.kitchen_driver =='docker' else 'False' }}
-
-{%- if cookiecutter.kitchen_driver =='docker' %}
-
-
-platforms:
-  - name: ubuntu-14.04
-  - name: ubuntu-16.04
-  - name: centos-7.1
-
 
 verifier:
   name: {{ cookiecutter.kitchen_verifier }}
   sudo: true
 
+{%- if cookiecutter.kitchen_driver =='docker' %}
+platforms:
+  - name: ubuntu-trusty
+    driver_config:
+      image: trevorj/salty-whales:trusty
+      platform: ubuntu
+
+  - name: ubuntu-xenial
+    driver_config:
+      image: trevorj/salty-whales:xenial
+      platform: ubuntu
 
 suites:
   {%- if cookiecutter.kitchen_suites == "" %}
@@ -58,5 +59,4 @@ suites:
   {%- endif %}
 
 {%- endif %}
-
 # vim: ft=yaml sw=2 ts=2 sts=2 tw=125

--- a/cookiecutter/salt-formula/{{cookiecutter.service_name}}/.kitchen.docker.yml
+++ b/cookiecutter/salt-formula/{{cookiecutter.service_name}}/.kitchen.docker.yml
@@ -1,0 +1,62 @@
+---
+driver:
+  name: docker
+  hostname: {{ cookiecutter.kitchen_formula }}.ci.local
+  #socket: tcp://127.0.0.1:2376
+  use_sudo: false
+
+
+
+provisioner:
+  name: salt_solo
+  salt_install: bootstrap
+  salt_bootstrap_url: https://bootstrap.saltstack.com
+  salt_version: latest
+  require_chef: false
+  formula: {{ cookiecutter.kitchen_formula }}
+  log_level: info
+  state_top:
+    base:
+      "*":
+        - {{ cookiecutter.kitchen_formula }}
+  pillars:
+    top.sls:
+      base:
+        "*":
+          - {{ cookiecutter.kitchen_formula }}
+  grains:
+    noservices: {{ 'True' if cookiecutter.kitchen_driver =='docker' else 'False' }}
+
+{%- if cookiecutter.kitchen_driver =='docker' %}
+
+
+platforms:
+  - name: ubuntu-14.04
+  - name: ubuntu-16.04
+  - name: centos-7.1
+
+
+verifier:
+  name: {{ cookiecutter.kitchen_verifier }}
+  sudo: true
+
+
+suites:
+  {%- if cookiecutter.kitchen_suites == "" %}
+  - name: default
+  #  provisioner:
+  #    pillars-from-files:
+  #      {{ cookiecutter.kitchen_formula }}.sls: tests/pillar/default.sls
+  {%- else %}
+  {%- for suite in cookiecutter.kitchen_suites.split() %}
+
+  - name: {{ suite }}
+    provisioner:
+      pillars-from-files:
+        {{ cookiecutter.kitchen_formula }}.sls: tests/pillar/{{suite}}.sls
+  {%- endfor %}
+  {%- endif %}
+
+{%- endif %}
+
+# vim: ft=yaml sw=2 ts=2 sts=2 tw=125

--- a/cookiecutter/salt-formula/{{cookiecutter.service_name}}/.kitchen.openstack.yml
+++ b/cookiecutter/salt-formula/{{cookiecutter.service_name}}/.kitchen.openstack.yml
@@ -1,0 +1,66 @@
+
+# usage: `KITCHEN_LOCAL_YAML=.kitchen.openstack.yml kitchen test`
+
+# https://docs.chef.io/config_yml_kitchen.html
+# https://github.com/test-kitchen/kitchen-openstack
+
+---
+driver:
+  name: openstack
+  openstack_auth_url: <%= ENV['OS_AUTH_URL'] %>/tokens
+  openstack_username: <%= ENV['OS_USERNAME'] || 'ci' %>
+  openstack_api_key:  <%= ENV['OS_PASSWORD'] || 'ci' %>
+  openstack_tenant:   <%= ENV['OS_TENANT_NAME'] || 'ci_jenkins' %>
+
+  #floating_ip_pool: <%= ENV['OS_FLOATING_IP_POOL'] || 'nova' %>
+  key_name: <%= ENV['BOOTSTRAP_SSH_KEY_NAME'] || 'bootstrap_insecure' %>
+  private_key_path: <%= ENV['BOOTSTRAP_SSH_KEY_PATH'] || "#{ENV['HOME']}/.ssh/id_rsa_bootstrap_insecure" %>
+
+
+platforms:
+  - name: ubuntu-14.04
+    driver:
+      username: <%= ENV['OS_UBUNTU_IMAGE_USER'] || 'root' %>
+      image_ref: <%= ENV['OS_UBUNTU_IMAGE_REF'] || 'ubuntu-14-04-x64-1455869035' %>
+      flavor_ref: m1.medium
+      network_ref:
+        <% if ENV['OS_NETWORK_REF'] -%>
+        - <% ENV['OS_NETWORK_REF'] %>
+        <% else -%>
+        - ci-net
+        <% end -%>
+    # force update apt cache on the image
+    run_list:
+      - recipe[apt]
+    attributes:
+      apt:
+          compile_time_update: true
+transport:
+  username: <%= ENV['OS_UBUNTU_IMAGE_USER'] || 'root' %>
+
+{%- if cookiecutter.kitchen_driver =='openstack' %}
+
+verifier:
+  name: {{ cookiecutter.kitchen_verifier }}
+  sudo: true
+
+
+suites:
+  {%- if cookiecutter.kitchen_suites == "" %}
+  - name: default
+  #  provisioner:
+  #    pillars-from-files:
+  #      {{ cookiecutter.kitchen_formula }}.sls: tests/pillar/default.sls
+  {%- else %}
+  {%- for suite in cookiecutter.kitchen_suites.split() %}
+
+  - name: {{ suite }}
+    provisioner:
+      pillars-from-files:
+        {{ cookiecutter.kitchen_formula }}.sls: tests/pillar/{{suite}}.sls
+  {%- endfor %}
+  {%- endif %}
+
+{%- endif %}
+
+# vim: ft=yaml sw=2 ts=2 sts=2 tw=125

--- a/cookiecutter/salt-formula/{{cookiecutter.service_name}}/.kitchen.vagrant.yml
+++ b/cookiecutter/salt-formula/{{cookiecutter.service_name}}/.kitchen.vagrant.yml
@@ -1,0 +1,62 @@
+---
+driver:
+  name: vagrant
+  vm_hostname: {{ cookiecutter.kitchen_formula }}.ci.local
+  use_sudo: false
+  customize:
+    memory: 512
+
+
+provisioner:
+  name: salt_solo
+  salt_install: bootstrap
+  salt_bootstrap_url: https://bootstrap.saltstack.com
+  salt_version: latest
+  require_chef: false
+  formula: {{ cookiecutter.kitchen_formula }}
+  log_level: info
+  state_top:
+    base:
+      "*":
+        - {{ cookiecutter.kitchen_formula }}
+  pillars:
+    top.sls:
+      base:
+        "*":
+          - {{ cookiecutter.kitchen_formula }}
+  grains:
+    noservices: {{ 'True' if cookiecutter.kitchen_driver =='docker' else 'False' }}
+
+{%- if cookiecutter.kitchen_driver =='vagrant' %}
+
+
+platforms:
+  - name: ubuntu-14.04
+  - name: ubuntu-16.04
+  - name: centos-7.1
+
+
+verifier:
+  name: {{ cookiecutter.kitchen_verifier }}
+  sudo: true
+
+
+suites:
+  {%- if cookiecutter.kitchen_suites == "" %}
+  - name: default
+  #  provisioner:
+  #    pillars-from-files:
+  #      {{ cookiecutter.kitchen_formula }}.sls: tests/pillar/default.sls
+  {%- else %}
+  {%- for suite in cookiecutter.kitchen_suites.split() %}
+
+  - name: {{ suite }}
+    provisioner:
+      pillars-from-files:
+        {{ cookiecutter.kitchen_formula }}.sls: tests/pillar/{{suite}}.sls
+  {%- endfor %}
+  {%- endif %}
+
+{%- endif %}
+
+# vim: ft=yaml sw=2 ts=2 sts=2 tw=125

--- a/cookiecutter/salt-formula/{{cookiecutter.service_name}}/.travis.yml
+++ b/cookiecutter/salt-formula/{{cookiecutter.service_name}}/.travis.yml
@@ -1,0 +1,25 @@
+sudo: required
+services:
+  - docker
+
+install:
+  - pip install PyYAML
+  - pip install virtualenv
+  - |
+    test -e Gemfile || cat <<EOF > Gemfile
+    source 'https://rubygems.org'
+    gem 'rake'
+    gem 'test-kitchen'
+    gem 'kitchen-docker'
+    gem 'kitchen-inspec'
+    gem 'inspec'
+    gem 'kitchen-salt', :git => 'https://github.com/epcim/kitchen-salt.git', :branch => 'dependencis-pkg-repo2'
+    #Waiting for PR#78
+    #gem 'kitchen-salt', '>=0.2.25'
+  - bundle install
+
+before_script:
+  - make test
+
+script:
+  - test ! -e .kitchen.yml || bundle exec kitchen test


### PR DESCRIPTION
there is an salt-formulas/cookiecutter-salt-formula up to date, this commit sync cookiecutter/salt-formula with that. Otherwise state right now in cookiecutter/salt-formula I guess is broken. Where the cookiecutter will live?